### PR TITLE
Use getUrl and getScriptName instead of a hardcoded URL

### DIFF
--- a/public/config.php
+++ b/public/config.php
@@ -23,6 +23,7 @@ $app->db = $capsule;
  * Extract settings from db
  */
 $settings = Settings::where('id', '=', 1)->first();
+$settings->base_url = $app->request->getUrl() . $app->request->getScriptName();
 
 /**
  * Set template directory


### PR DESCRIPTION
Use getUrl and getScriptName instead of a hardcoded URL in the database. This makes the installation a bit easier as the SQL file doesn't have to be modified.

The Site URL field should also be removed from the settings view and the settings table as it's not needed anymore.
