### PR TITLE
Move database config to its own file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 !vendor/*
 !/nbproject/*
 /vendor/
+config/database.config.php

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install
 ---
 * Run 'php composer.phar install' in root directory
 * Run .sql files located in SQL/updates
-* Edit config.php file under public folder at 12 line with your database login data
+* Rename the config/database.config.php.install file to config/database.config.php and edit it with your database settings
 * Login with username:password
 * Enjoy
 

--- a/config/database.config.php.install
+++ b/config/database.config.php.install
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Database settings
+ */
+return array(
+    'driver' => 'mysql',
+    'host' => 'localhost',
+    'database' => 'slimblog',
+    'username' => 'root',
+    'password' => '',
+    'prefix' => '',
+    'charset' => 'utf8',
+    'collation' => 'utf8_general_ci',
+);

--- a/public/config.php
+++ b/public/config.php
@@ -4,16 +4,7 @@ $app->add(new \Slim\Middleware\SessionCookie(array('secret' => 'h5/4jc/)$3kfè4(
 // Make a new connection
 use Illuminate\Database\Capsule\Manager as Capsule;
 $capsule = new Capsule;
-$capsule->addConnection(array(
-    'driver' => 'mysql',
-    'host' => 'localhost',
-    'database' => 'slimblog',
-    'username' => 'root',
-    'password' => '',
-    'prefix' => '',
-    'charset' => 'utf8',
-    'collation' => 'utf8_general_ci',
-));
+$capsule->addConnection(include ROOT . "config" . DS . 'database.config.php');
 $capsule->bootEloquent();
 $capsule->setAsGlobal();
 


### PR DESCRIPTION
Move the database settings to its own file. This makes it easier if we want to create a web based installer.

I also added the new config file to .gitignore so we don't have to worry about pushing our own settings while developing.
